### PR TITLE
Updating to node-v0.12.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir -p /var/log/supervisor
 RUN echo Europe/Vienna > /etc/timezone && dpkg-reconfigure tzdata
 
 # Install Homebridge
-RUN wget https://nodejs.org/dist/latest-v0.12.x/node-v0.12.9-linux-x64.tar.gz -P /tmp && cd /usr/local && tar xzvf /tmp/node-v0.12.9-linux-x64.tar.gz --strip=1
+RUN wget https://nodejs.org/dist/latest-v0.12.x/node-v0.12.10-linux-x64.tar.gz -P /tmp && cd /usr/local && tar xzvf /tmp/node-v0.12.10-linux-x64.tar.gz --strip=1
 
 RUN ln -s /usr/local/bin/node /usr/bin/node
 


### PR DESCRIPTION
Downloading https://nodejs.org/dist/latest-v0.12.x/node-v0.12.9-linux-x64.tar.gz throws a 404 error. 
Updated Dockerfile to node-v0.12.10.
